### PR TITLE
feat(analytics): add T1.1 latency + T2.3 recipe interactions endpoints

### DIFF
--- a/alembic/versions/f1a2b3c4d5e6_add_inventory_matches_to_interactions.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_inventory_matches_to_interactions.py
@@ -1,0 +1,34 @@
+"""add inventory_matches to recipe_interactions
+
+Revision ID: f1a2b3c4d5e6
+Revises: e1f2a3b4c5d6, d4e5f6a1b2c3
+Create Date: 2026-05-07 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, Sequence[str]] = ('e1f2a3b4c5d6', 'd4e5f6a1b2c3')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'recipe_interactions',
+        sa.Column('inventory_matches', sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        'ix_recipe_interactions_action_occurred',
+        'recipe_interactions',
+        ['action', 'occurred_at'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_recipe_interactions_action_occurred', table_name='recipe_interactions')
+    op.drop_column('recipe_interactions', 'inventory_matches')

--- a/app/analytics/router.py
+++ b/app/analytics/router.py
@@ -12,10 +12,16 @@ from app.analytics.schemas import (
     AnalyticsEventResponse,
     DashboardResponse,
     EventsSummaryResponse,
+    InventoryEventsSummaryResponse,
     MarketProductTrendsResponse,
+    MatchBucket,
+    NotificationLatencyResponse,
+    RecipeInteractionsSummary,
     SavingsResponse,
     SeedDemoResponse,
+    TopCookedRecipe,
     UserSegmentResponse,
+    ViewsVsCooksRow,
     WasteSummaryResponse,
     WasteTrendItem,
 )
@@ -133,3 +139,69 @@ def get_top_products(
     Ejecutar primero `POST /market/seed-demo` si la BD está vacía.
     """
     return analytics_service.get_top_products(db, top_n=top_n, category=category, min_users=min_users)
+
+
+# ── T1.1: Notification latency & inventory events ────────────────────────────
+
+@router.get("/notification-latency", response_model=NotificationLatencyResponse)
+def notification_latency(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Latencia entre registro de ítem y primera notificación recibida."""
+    return analytics_service.get_notification_latency(db, days=days)
+
+
+@router.get("/inventory-events/summary", response_model=InventoryEventsSummaryResponse)
+def inventory_events_summary(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Total de ítems registrados y cuántos eran elegibles para alerta (≤3 días al vencer)."""
+    return analytics_service.get_inventory_events_summary(db, days=days)
+
+
+# ── T2.3: Recipe interactions ─────────────────────────────────────────────────
+
+@router.get("/recipe-interactions/summary", response_model=RecipeInteractionsSummary)
+def recipe_interactions_summary(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Resumen de interacciones: total cocinado/visto, cook-through rate y matches promedio."""
+    return analytics_service.get_recipe_interactions_summary(db, days=days)
+
+
+@router.get("/recipe-interactions/top-cooked", response_model=list[TopCookedRecipe])
+def top_cooked_recipes(
+    days: int = Query(30, ge=1, le=365),
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Ranking de recetas más cocinadas en los últimos N días."""
+    return analytics_service.get_top_cooked_recipes(db, days=days, limit=limit)
+
+
+@router.get("/recipe-interactions/views-vs-cooks", response_model=list[ViewsVsCooksRow])
+def views_vs_cooks(
+    days: int = Query(30, ge=1, le=365),
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Comparativo de vistas vs cocinadas por receta con cook-through rate individual."""
+    return analytics_service.get_views_vs_cooks(db, days=days, limit=limit)
+
+
+@router.get("/recipe-interactions/match-distribution", response_model=list[MatchBucket])
+def match_distribution(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Histograma de inventory_matches al momento de cocinar (1/2/3/4/5+)."""
+    return analytics_service.get_match_distribution(db, days=days)

--- a/app/analytics/schemas.py
+++ b/app/analytics/schemas.py
@@ -105,3 +105,53 @@ class SeedDemoResponse(BaseModel):
     users_created: int
     items_created: int
     events_created: int
+
+
+# ── T1.1: Notification latency & inventory events ────────────────────────────
+
+class LatencyBucket(BaseModel):
+    bucket: str
+    count: int
+
+
+class NotificationLatencyResponse(BaseModel):
+    avg_seconds: float
+    p50_seconds: float
+    p95_seconds: float
+    max_seconds: float
+    sample_size: int
+    histogram: list[LatencyBucket]
+    period_days: int
+
+
+class InventoryEventsSummaryResponse(BaseModel):
+    total_registered: int
+    eligible_for_alert: int
+    period_days: int
+
+
+# ── T2.3: Recipe interactions ─────────────────────────────────────────────────
+
+class RecipeInteractionsSummary(BaseModel):
+    total_cooked: int
+    total_viewed: int
+    cook_through_rate: float
+    avg_inventory_matches_on_cook: Optional[float]
+    period_days: int
+
+
+class TopCookedRecipe(BaseModel):
+    name: str
+    cooks: int
+
+
+class ViewsVsCooksRow(BaseModel):
+    name: str
+    views: int
+    cooks: int
+    rate_pct: Optional[float]
+
+
+class MatchBucket(BaseModel):
+    matches: str
+    count: int

--- a/app/analytics/service.py
+++ b/app/analytics/service.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import Optional
 import uuid
 
-from sqlalchemy import Date, cast, extract, func
+from sqlalchemy import Date, cast, extract, func, text
 from sqlalchemy.orm import Session
 
 from app.auth.models import User
@@ -604,3 +604,213 @@ def seed_demo_market_data(db: Session) -> SeedDemoResponse:
         items_created=created_items,
         events_created=created_events,
     )
+
+
+# ── T1.1: Notification latency ────────────────────────────────────────────────
+
+def get_notification_latency(db: Session, days: int = 30) -> dict:
+    stats_sql = text("""
+        WITH first_notification AS (
+            SELECT (metadata->>'item_id')::uuid AS item_id,
+                   MIN(occurred_at)             AS first_notif_at
+            FROM analytics_events
+            WHERE event_name = 'notification_received'
+              AND metadata ? 'item_id'
+            GROUP BY metadata->>'item_id'
+        ),
+        latencies AS (
+            SELECT EXTRACT(EPOCH FROM (fn.first_notif_at - r.occurred_at)) AS seconds
+            FROM inventory_events r
+            JOIN first_notification fn ON fn.item_id = r.item_id
+            WHERE r.event_type = 'registered'
+              AND r.occurred_at > NOW() - (:days || ' days')::interval
+              AND fn.first_notif_at > r.occurred_at
+        )
+        SELECT
+            COUNT(*)                                                            AS sample_size,
+            COALESCE(AVG(seconds), 0)                                           AS avg_seconds,
+            COALESCE(PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY seconds), 0) AS p50_seconds,
+            COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY seconds), 0) AS p95_seconds,
+            COALESCE(MAX(seconds), 0)                                           AS max_seconds
+        FROM latencies;
+    """)
+    stats = db.execute(stats_sql, {"days": days}).mappings().one()
+
+    histogram_sql = text("""
+        WITH first_notification AS (
+            SELECT (metadata->>'item_id')::uuid AS item_id,
+                   MIN(occurred_at)             AS first_notif_at
+            FROM analytics_events
+            WHERE event_name = 'notification_received'
+              AND metadata ? 'item_id'
+            GROUP BY metadata->>'item_id'
+        ),
+        latencies AS (
+            SELECT EXTRACT(EPOCH FROM (fn.first_notif_at - r.occurred_at))/60.0 AS minutes
+            FROM inventory_events r
+            JOIN first_notification fn ON fn.item_id = r.item_id
+            WHERE r.event_type = 'registered'
+              AND r.occurred_at > NOW() - (:days || ' days')::interval
+              AND fn.first_notif_at > r.occurred_at
+        ),
+        buckets AS (
+            SELECT
+                CASE
+                    WHEN minutes < 1   THEN '0-1 min'
+                    WHEN minutes < 5   THEN '1-5 min'
+                    WHEN minutes < 30  THEN '5-30 min'
+                    WHEN minutes < 60  THEN '30-60 min'
+                    ELSE                    '>60 min'
+                END AS bucket,
+                CASE
+                    WHEN minutes < 1   THEN 1
+                    WHEN minutes < 5   THEN 2
+                    WHEN minutes < 30  THEN 3
+                    WHEN minutes < 60  THEN 4
+                    ELSE                    5
+                END AS sort_order
+            FROM latencies
+        )
+        SELECT bucket, sort_order, COUNT(*) AS count
+        FROM buckets
+        GROUP BY bucket, sort_order
+        ORDER BY sort_order;
+    """)
+    rows = db.execute(histogram_sql, {"days": days}).mappings().all()
+
+    return {
+        "avg_seconds": float(stats["avg_seconds"]),
+        "p50_seconds": float(stats["p50_seconds"]),
+        "p95_seconds": float(stats["p95_seconds"]),
+        "max_seconds": float(stats["max_seconds"]),
+        "sample_size": int(stats["sample_size"]),
+        "histogram": [{"bucket": r["bucket"], "count": int(r["count"])} for r in rows],
+        "period_days": days,
+    }
+
+
+def get_inventory_events_summary(db: Session, days: int = 30) -> dict:
+    sql = text("""
+        SELECT
+            COUNT(*) FILTER (WHERE r.event_type = 'registered') AS total_registered,
+            COUNT(*) FILTER (
+                WHERE r.event_type = 'registered'
+                  AND (i.expiry_date - r.occurred_at::date) <= 3
+            ) AS eligible_for_alert
+        FROM inventory_events r
+        LEFT JOIN inventory_items i ON i.id = r.item_id
+        WHERE r.occurred_at > NOW() - (:days || ' days')::interval;
+    """)
+    row = db.execute(sql, {"days": days}).mappings().one()
+    return {
+        "total_registered": int(row["total_registered"] or 0),
+        "eligible_for_alert": int(row["eligible_for_alert"] or 0),
+        "period_days": days,
+    }
+
+
+# ── T2.3: Recipe interactions ─────────────────────────────────────────────────
+
+def get_recipe_interactions_summary(db: Session, days: int = 30) -> dict:
+    sql = text("""
+        SELECT
+            SUM(CASE WHEN action='cooked' THEN 1 ELSE 0 END) AS total_cooked,
+            SUM(CASE WHEN action='viewed' THEN 1 ELSE 0 END) AS total_viewed,
+            ROUND(
+                100.0 * SUM(CASE WHEN action='cooked' THEN 1 ELSE 0 END)::numeric
+                      / NULLIF(SUM(CASE WHEN action='viewed' THEN 1 ELSE 0 END), 0),
+                1
+            ) AS cook_through_rate,
+            ROUND(AVG(CASE WHEN action='cooked' THEN inventory_matches END)::numeric, 1)
+                AS avg_inventory_matches_on_cook
+        FROM recipe_interactions
+        WHERE occurred_at > NOW() - (:days || ' days')::interval;
+    """)
+    row = db.execute(sql, {"days": days}).mappings().one()
+    return {
+        "total_cooked": int(row["total_cooked"] or 0),
+        "total_viewed": int(row["total_viewed"] or 0),
+        "cook_through_rate": float(row["cook_through_rate"] or 0),
+        "avg_inventory_matches_on_cook": (
+            float(row["avg_inventory_matches_on_cook"])
+            if row["avg_inventory_matches_on_cook"] is not None else None
+        ),
+        "period_days": days,
+    }
+
+
+def get_top_cooked_recipes(db: Session, days: int = 30, limit: int = 10) -> list[dict]:
+    sql = text("""
+        SELECT r.name, COUNT(*) AS cooks
+        FROM recipe_interactions ri
+        JOIN recipes r ON r.id = ri.recipe_id
+        WHERE ri.action = 'cooked'
+          AND ri.occurred_at > NOW() - (:days || ' days')::interval
+        GROUP BY r.name
+        ORDER BY cooks DESC
+        LIMIT :limit;
+    """)
+    rows = db.execute(sql, {"days": days, "limit": limit}).mappings().all()
+    return [{"name": r["name"], "cooks": int(r["cooks"])} for r in rows]
+
+
+def get_views_vs_cooks(db: Session, days: int = 30, limit: int = 10) -> list[dict]:
+    sql = text("""
+        SELECT
+            r.name,
+            SUM(CASE WHEN ri.action='viewed' THEN 1 ELSE 0 END) AS views,
+            SUM(CASE WHEN ri.action='cooked' THEN 1 ELSE 0 END) AS cooks,
+            ROUND(
+                100.0 * SUM(CASE WHEN ri.action='cooked' THEN 1 ELSE 0 END)::numeric
+                      / NULLIF(SUM(CASE WHEN ri.action='viewed' THEN 1 ELSE 0 END), 0),
+                1
+            ) AS rate_pct
+        FROM recipe_interactions ri
+        JOIN recipes r ON r.id = ri.recipe_id
+        WHERE ri.occurred_at > NOW() - (:days || ' days')::interval
+        GROUP BY r.name
+        ORDER BY cooks DESC, views DESC
+        LIMIT :limit;
+    """)
+    rows = db.execute(sql, {"days": days, "limit": limit}).mappings().all()
+    return [
+        {
+            "name": r["name"],
+            "views": int(r["views"] or 0),
+            "cooks": int(r["cooks"] or 0),
+            "rate_pct": float(r["rate_pct"]) if r["rate_pct"] is not None else None,
+        }
+        for r in rows
+    ]
+
+
+def get_match_distribution(db: Session, days: int = 30) -> list[dict]:
+    sql = text("""
+        WITH labeled AS (
+            SELECT
+                CASE
+                    WHEN inventory_matches = 1 THEN '1'
+                    WHEN inventory_matches = 2 THEN '2'
+                    WHEN inventory_matches = 3 THEN '3'
+                    WHEN inventory_matches = 4 THEN '4'
+                    WHEN inventory_matches >= 5 THEN '5+'
+                END AS matches,
+                CASE
+                    WHEN inventory_matches = 1 THEN 1
+                    WHEN inventory_matches = 2 THEN 2
+                    WHEN inventory_matches = 3 THEN 3
+                    WHEN inventory_matches = 4 THEN 4
+                    WHEN inventory_matches >= 5 THEN 5
+                END AS sort_order
+            FROM recipe_interactions
+            WHERE action = 'cooked'
+              AND inventory_matches IS NOT NULL
+              AND occurred_at > NOW() - (:days || ' days')::interval
+        )
+        SELECT matches, sort_order, COUNT(*) AS count
+        FROM labeled
+        GROUP BY matches, sort_order
+        ORDER BY sort_order;
+    """)
+    rows = db.execute(sql, {"days": days}).mappings().all()
+    return [{"matches": r["matches"], "count": int(r["count"])} for r in rows]

--- a/app/recipes/models.py
+++ b/app/recipes/models.py
@@ -40,10 +40,11 @@ class RecipeIngredient(Base):
 class RecipeInteraction(Base):
     __tablename__ = "recipe_interactions"
 
-    id          = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id     = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    recipe_id   = Column(UUID(as_uuid=True), ForeignKey("recipes.id"), nullable=False)
-    action      = Column(String(20), nullable=False)   # 'viewed', 'cooked'
-    occurred_at = Column(DateTime, default=datetime.utcnow)
+    id                = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id           = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    recipe_id         = Column(UUID(as_uuid=True), ForeignKey("recipes.id"), nullable=False)
+    action            = Column(String(20), nullable=False)   # 'viewed', 'cooked'
+    inventory_matches = Column(Integer, nullable=True)
+    occurred_at       = Column(DateTime, default=datetime.utcnow)
 
     recipe = relationship("Recipe", back_populates="interactions")

--- a/app/recipes/service.py
+++ b/app/recipes/service.py
@@ -140,18 +140,13 @@ def interact(
 ) -> None:
     recipe = _get_recipe_or_404(db, recipe_id)
 
-    interaction = RecipeInteraction(
-        user_id=user_id,
-        recipe_id=recipe.id,
-        action=action,
-    )
-    db.add(interaction)
-
+    matches = None
     if action == "cooked":
-        # Marcar como consumidos los ítems del inventario que coincidan con ingredientes
         active_items = _get_active_items(db, user_id)
-        consumed_ids: set[uuid.UUID] = set()
+        active_names = {item.name for item in active_items}
+        matches = _compute_matches(recipe, active_names)
 
+        consumed_ids: set[uuid.UUID] = set()
         for ing in recipe.ingredients:
             for item in active_items:
                 if item.id not in consumed_ids and _item_matches_ingredient(item.name, ing.ingredient_name):
@@ -166,6 +161,13 @@ def interact(
                     )
                     db.add(event)
 
+    interaction = RecipeInteraction(
+        user_id=user_id,
+        recipe_id=recipe.id,
+        action=action,
+        inventory_matches=matches,
+    )
+    db.add(interaction)
     db.commit()
 
 


### PR DESCRIPTION
Endpoints nuevos para el dashboard (BQ T1.1 y T2.3):

T1.1 - Sistema de alertas:
- GET /api/v1/analytics/notification-latency?days=N → avg/p50/p95/max + histograma por buckets (5 rangos)
- GET /api/v1/analytics/inventory-events/summary?days=N → total_registered + eligible_for_alert (≤3 días al expirar)

T2.3 - Interacciones con recetas:
- GET /api/v1/analytics/recipe-interactions/summary
- GET /api/v1/analytics/recipe-interactions/top-cooked
- GET /api/v1/analytics/recipe-interactions/views-vs-cooks
- GET /api/v1/analytics/recipe-interactions/match-distribution

Cambios adicionales:
- Migración: columna inventory_matches (nullable int) en recipe_interactions
- POST /recipes/{id}/interact persiste inventory_matches al cocinar

Reusa get_db() y get_current_user(); sin breaking changes.